### PR TITLE
#29 Fixed Redis cache

### DIFF
--- a/src/main/java/com/solvd/userservice/service/impl/UserQueryServiceImpl.java
+++ b/src/main/java/com/solvd/userservice/service/impl/UserQueryServiceImpl.java
@@ -5,7 +5,7 @@ import com.solvd.userservice.domain.exception.UserNotFoundException;
 import com.solvd.userservice.repository.UserRepository;
 import com.solvd.userservice.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.ReactiveRedisOperations;
+import org.springframework.data.redis.core.ReactiveHashOperations;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
@@ -14,33 +14,43 @@ import reactor.core.publisher.Mono;
 public class UserQueryServiceImpl implements UserQueryService {
 
     private final UserRepository userRepository;
-    private final ReactiveRedisOperations<String, User> userOps;
+    private final ReactiveHashOperations<String, String, User> hashOps;
 
     @Override
     public Mono<User> getById(final String id) {
+        return hashOps.get("user", id)
+                .switchIfEmpty(getByIdAndCache(id));
+    }
+
+    private Mono<User> getByIdAndCache(final String userId) {
         Mono<User> error = Mono.error(
-                new UserNotFoundException("User with id " + id + " not found")
+                new UserNotFoundException("User with id "
+                        + userId
+                        + " not found")
         );
-        return userOps.opsForValue()
-                .get(id)
-                .switchIfEmpty(userRepository.findById(id)
-                        .switchIfEmpty(error)
-                        .onErrorResume(Mono::error)
-                        .map(u -> {
-                            userOps.opsForValue().set(id, u).subscribe();
-                            return u;
-                        }))
-                .flatMap(u -> userOps.opsForValue().get(id));
+        return userRepository
+                .findById(userId)
+                .switchIfEmpty(error)
+                .flatMap(user -> hashOps.put("user", userId, user)
+                        .thenReturn(user));
     }
 
     @Override
     public Mono<User> getByEmail(final String email) {
+        return hashOps.get("user", email)
+                .switchIfEmpty(getByEmailAndCache(email));
+    }
+
+    private Mono<User> getByEmailAndCache(final String email) {
         Mono<User> error = Mono.error(
                 new UserNotFoundException("User with email " + email
                         + " not found")
         );
-        return userRepository.findByEmail(email)
-                .switchIfEmpty(error);
+        return userRepository
+                .findByEmail(email)
+                .switchIfEmpty(error)
+                .flatMap(user -> hashOps.put("user", email, user)
+                        .thenReturn(user));
     }
 
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR replaces the Redis `ReactiveRedisOperations` with `ReactiveHashOperations` in `UserQueryServiceImpl` and `WebConfig`. It also updates the Redis serialization context to use `ReactiveRedisTemplate` with a hash key and value. 

### Detailed summary
- Replaces `ReactiveRedisOperations` with `ReactiveHashOperations` in `UserQueryServiceImpl`
- Updates Redis serialization context to use `ReactiveRedisTemplate` with hash key and value in `WebConfig`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->